### PR TITLE
bump ingress image to 0.9.0-beta.11

### DIFF
--- a/nginx-ingress/templates/ingress-service.yaml
+++ b/nginx-ingress/templates/ingress-service.yaml
@@ -2,13 +2,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-nginx-ingress
+  name: {{ .Release.Name }}-service
+  namespace: {{ .Release.Namespace }}
   labels:
-    name: {{ .Release.Name }}-nginx-ingress
+    name: {{ .Release.Name }}-service
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
-    component: "{{.Release.Name}}-nginx-ingress"
+    component: "{{.Release.Name}}"
   annotations:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
@@ -44,4 +45,4 @@ spec:
   {{- end}}
   {{- end}}
   selector:
-    k8s-app: {{ .Release.Name }}-nginx-ingress-lb
+    k8s-app: {{ .Release.Name }}-lb

--- a/nginx-ingress/templates/ingress.yaml
+++ b/nginx-ingress/templates/ingress.yaml
@@ -2,27 +2,28 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-nginx-ingress-controller
+  name: {{ .Release.Name }}-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     heritage: {{.Release.Service | quote }}
     release: {{.Release.Name | quote }}
     chart: "{{.Chart.Name}}-{{.Chart.Version}}"
-    component: "{{.Release.Name}}-nginx-ingress"
+    component: "{{.Release.Name}}"
   annotations:
     "helm.sh/created": {{.Release.Time.Seconds | quote }}
 spec:
   replicas: {{.Values.ingressController.replicas}}
   selector:
     matchLabels:
-        k8s-app: {{ .Release.Name }}-nginx-ingress-lb
+        k8s-app: {{ .Release.Name }}-lb
   template:
     metadata:
       labels:
-        k8s-app: {{ .Release.Name }}-nginx-ingress-lb
+        k8s-app: {{ .Release.Name }}-lb
     spec:
-      serviceAccountName: {{ .Release.Name }}-nginx-ingress-serviceaccount
+      serviceAccountName: {{ .Release.Name }}-serviceaccount
       containers:
-        - name: nginx-ingress-controller
+        - name: {{ .Release.Name }}-controller
           image: {{.Values.ingressController.image}}:{{.Values.ingressController.version}}
           args:
              - /nginx-ingress-controller
@@ -46,7 +47,7 @@ spec:
                valueFrom:
                  fieldRef:
                    fieldPath: metadata.name
-               name: POD_NAMESPACE
+             - name: POD_NAMESPACE
                valueFrom:
                  fieldRef:
                    fieldPath: metadata.namespace

--- a/nginx-ingress/templates/rbac.yaml
+++ b/nginx-ingress/templates/rbac.yaml
@@ -85,6 +85,7 @@ rules:
       - configmaps
     verbs:
       - create
+      - update
   - apiGroups:
       - ""
     resources:

--- a/nginx-ingress/templates/rbac.yaml
+++ b/nginx-ingress/templates/rbac.yaml
@@ -3,12 +3,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-nginx-ingress-serviceaccount
+  name: {{ .Release.Name }}-serviceaccount
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}-nginx-ingress-clusterrole
+  name: {{ .Release.Name }}-clusterrole
 rules:
   - apiGroups:
       - ""
@@ -104,19 +104,19 @@ roleRef:
   name: nginx-ingress-role
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-nginx-ingress-serviceaccount
+    name: {{ .Release.Name }}-serviceaccount
     namespace: {{ .Release.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-nginx-ingress-clusterrole-nisa-binding
+  name: {{ .Release.Name }}-clusterrole-nisa-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}-nginx-ingress-clusterrole
+  name: {{ .Release.Name }}-clusterrole
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-nginx-ingress-serviceaccount
+    name: {{ .Release.Name }}-serviceaccount
     namespace: {{ .Release.Namespace}}
 {{- end}}

--- a/nginx-ingress/values.yaml
+++ b/nginx-ingress/values.yaml
@@ -19,7 +19,7 @@ tcpServices:
 
 ingressController:
   image: gcr.io/google_containers/nginx-ingress-controller
-  version: "0.9.0-beta.8"
+  version: "0.9.0-beta.11"
   ports:
   - name: http
     number: 80


### PR DESCRIPTION
* 0.9.0-beta.8 has a bug that prevents LE from getting host validation. Bump to 0.9.0-beta.11 and fix a missing env variable.
* Remove various string redundancies.